### PR TITLE
Default to Basic Financials scenario after API key is entered

### DIFF
--- a/src/ChatApp.jsx
+++ b/src/ChatApp.jsx
@@ -654,6 +654,11 @@ export default function ChatApp() {
   const handleSaveApiKey = (key) => {
     setApiKey(key);
     localStorage.setItem('openrouter_api_key', key);
+    // Default to Basic Financials scenario if no scenario has been chosen yet
+    if (!promptKey) {
+      setPromptKey('basic-financials');
+      localStorage.setItem('chatapp_prompt_mode', 'basic-financials');
+    }
   };
 
   // Save model to localStorage


### PR DESCRIPTION
When a student saves their OpenRouter API key for the first time (and no scenario has been previously chosen), automatically select the 'basic-financials' prompt mode so they land in a ready-to-use state.